### PR TITLE
Fix sum function answer (again)

### DIFF
--- a/ANSWERS.md
+++ b/ANSWERS.md
@@ -650,7 +650,8 @@ Joking aside though, if you're a job applicant skimming these answers so that yo
     ```js
     function add() {
       // Start from zero
-      var total = 0;
+      var int_total = 0, // integer total
+          dec_total = 0; // decimal total
 
       // Floating-points, bah!
       // 1e12 = 1000000000000.
@@ -662,21 +663,33 @@ Joking aside though, if you're a job applicant skimming these answers so that yo
       // Something to iterate on
       var i = arguments.length;
 
+      // truncate a number
+      function truncate(v) {
+          return Math[v >= 0 ? 'floor' : 'ceil'](v);
+      }
+
       // Loop through all the parameters
       while (i--) {
         // Multiply by 1e12, to account for peculiarities
         // of doing addition with floating-point numbers.
-        value = parseFloat(arguments[i]) * factor;
+        value = parseFloat(arguments[i]);
 
         // Is it not, not a number?
         // Then hey, it's a number!
         if (!isNaN(value)) {
-          total += value;
+
+          int_total += truncate(value);
+
+          // Multiply the decimal part by 1e12,
+          // to account for peculiarities of
+          // doing addition with floating-point numbers.
+          dec_total += truncate(value % 1 * factor);
+
         }
       }
 
       // Divide back by 1e12, because we multiplied by
       // 1e12 to account for floating-point weirdness.
-      return total/factor;
+      return int_total + dec_total/factor;
     }
     ```


### PR DESCRIPTION
The actual function doesn’t work on large values, [e.g.](https://github.com/nathansmith/javascript-quiz/pull/11#issuecomment-12463329):

``` js
add( 1e306 ) === Infinity; // true

add( 1e300, 1e300) === 1e300 + 1e300; // false
```

Multiplying a large value with another large value may result in an infinite one (JS doesn’t support numbers > 1e307). So, since the `factor` trick is used only to avoid weird decimal behavior, we have to split each value into an integer part and a decimal one, and multiply only the decimal one by `factor`. Then, we add the integer part and the decimal one divided by `factor`
